### PR TITLE
fix: update incorrect nav link URLs

### DIFF
--- a/src/components/pages/FoundationHeader.astro
+++ b/src/components/pages/FoundationHeader.astro
@@ -70,7 +70,13 @@ import FoundationLogo from "../FoundationLogo.astro";
           <a href="/news" aria-expanded="false">News &amp; events</a>
           <ul class="menu--level-2">
             <li class="menu-item menu-item--level-2">
-              <a href="/news">News</a>
+              <a href="/latest-news">News</a>
+            </li>
+            <li class="menu-item menu-item--level-2">
+              <a href="/events">Events</a>
+            </li>
+            <li class="menu-item menu-item--level-2">
+              <a href="/podcast">Podcast</a>
             </li>
           </ul>
         </li>


### PR DESCRIPTION
This PR fixes a couple of incorrect nav links that got pushed in the splash page rewrite PR.