### PR TITLE
fix: resolve overflow bug on mobile

### DIFF
--- a/src/layouts/HomeLayout.astro
+++ b/src/layouts/HomeLayout.astro
@@ -35,6 +35,7 @@ const { title, description } = Astro.props;
 	html {
 		box-sizing: border-box;
 		height: 100%;
+		overflow-x: hidden;
 	}
 
 	body {


### PR DESCRIPTION
`overflow-x: hidden` on the `body` element alone is insufficient for the off-screen menu to be properly hidden, it seems like both `html` and `body` need to have it. See https://stackoverflow.com/a/69291962/2873785