### PR TITLE
feat: add excerpt/description to blog listing

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,6 +1,5 @@
 import { defineConfig } from "astro/config";
 import starlight from "@astrojs/starlight";
-import { remarkDescription } from "./src/plugins/excerpt.mjs";
 
 // https://astro.build/config
 export default defineConfig({
@@ -104,9 +103,6 @@ export default defineConfig({
       ],
     }),
   ],
-  markdown: {
-    remarkPlugins: [remarkDescription],
-  },
   server: {
     port: 1103,
   },

--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -1,5 +1,6 @@
 import { defineConfig } from "astro/config";
 import starlight from "@astrojs/starlight";
+import { remarkDescription } from "./src/plugins/excerpt.mjs";
 
 // https://astro.build/config
 export default defineConfig({
@@ -103,6 +104,9 @@ export default defineConfig({
       ],
     }),
   ],
+  markdown: {
+    remarkPlugins: [remarkDescription],
+  },
   server: {
     port: 1103,
   },

--- a/package.json
+++ b/package.json
@@ -15,11 +15,9 @@
     "@types/showdown": "^2.0.6",
     "astro": "^4.5.1",
     "html-to-text": "^9.0.5",
+    "markdown-it": "^14.0.0",
     "node-html-parser": "^6.1.12",
     "sharp": "^0.33.2",
     "showdown": "^2.1.0"
-  },
-  "devDependencies": {
-    "markdown-it": "^14.0.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -13,9 +13,13 @@
     "@astrojs/starlight": "^0.21.1",
     "@interledger/docs-design-system": "^0.3.0",
     "@types/showdown": "^2.0.6",
-    "astro": "^4.4.15",
+    "astro": "^4.5.1",
+    "html-to-text": "^9.0.5",
     "node-html-parser": "^6.1.12",
     "sharp": "^0.33.2",
     "showdown": "^2.1.0"
+  },
+  "devDependencies": {
+    "markdown-it": "^14.0.0"
   }
 }

--- a/src/pages/blog/[...page].astro
+++ b/src/pages/blog/[...page].astro
@@ -1,5 +1,6 @@
 ---
 import type { Page } from "astro";
+import { createExcerpt } from '../../utils/create-excerpt';
 import BaseLayout from '../../layouts/BaseLayout.astro';
 import { getCollection } from 'astro:content';
 
@@ -27,14 +28,18 @@ const { page } = Astro.props;
 			</ol>
 			<h1>Engineering Blog</h1>
 			<ol class="postlist">
-				{((page as any).data || []).map((blogPostEntry: any) => (
-					<li class="postlist-item">
-						<a href={`/developers/blog/${blogPostEntry.slug}`} class="postlist-link heading--6">{blogPostEntry.data.title}</a>
-						<time class="postlist-date" datetime={blogPostEntry.data.date.toISOString()}>
-							{blogPostEntry.data.date.toDateString()}
-						</time>
-					</li>
-				))}
+				{((page as any).data || []).map((blogPostEntry: any) => {
+					const excerpt = `${createExcerpt(blogPostEntry.body).substring(0, 300)}...`;
+					return (
+						<li class="postlist-item">
+							<time class="postlist-date" datetime={blogPostEntry.data.date.toISOString()}>
+								{blogPostEntry.data.date.toDateString()}
+							</time>
+							<a href={`/developers/blog/${blogPostEntry.slug}`} class="postlist-link heading--6">{blogPostEntry.data.title}</a>
+							<p>{blogPostEntry.data.description ? blogPostEntry.data.description : excerpt}</p>
+						</li>
+					)}
+				)}
 			</ol>
 		</div>
 	</main>
@@ -86,7 +91,6 @@ ol {
 }
 
 .postlist-link {
-  order: 1;
 	font-weight: 600;
 	text-decoration-color: transparent;
 	transition: text-decoration 300ms ease-in-out, color 300ms ease-in-out;

--- a/src/utils/create-excerpt.js
+++ b/src/utils/create-excerpt.js
@@ -1,0 +1,18 @@
+import MarkdownIt from "markdown-it";
+import { convert } from "html-to-text";
+const parser = new MarkdownIt();
+
+export const createExcerpt = (body) => {
+  const html = parser.render(body);
+  const options = {
+    wordwrap: null,
+    selectors: [
+      { selector: "a", options: { ignoreHref: true } },
+      { selector: "img", format: "skip" },
+      { selector: "figure", format: "skip" },
+    ],
+  };
+  const text = convert(html, options);
+  const distilled = convert(text, options);
+  return distilled;
+};


### PR DESCRIPTION
Closes #44 

This PR adds a custom utility that generates the excerpt from a blog post if the description field in the frontmatter is not provided. The excerpt/description is displayed on the blog listing page.