### PR TITLE
chore: fix broken blog link and add tracking domain

### DIFF
--- a/src/content/blog/2018-10-03-interledger-how-to-interconnect-all-blockchains-and-value-networks.md
+++ b/src/content/blog/2018-10-03-interledger-how-to-interconnect-all-blockchains-and-value-networks.md
@@ -84,7 +84,7 @@ Connectors can optimize for speed and throughput, because every transaction— f
 The early Interledger network is optimized for micropayment use cases and trustlessly trading cryptocurrencies natively across blockchains. Here are some of the infrastructure and application companies building with ILP (and yes, they’re hiring!):
 
 - [Coil](https://coil.com/) is a subscription service for supporting web content creators underpinned by Interledger micropayments and the proposed [Web Monetization standard](https://webmonetization.org/). Link to [demo](https://www.youtube.com/watch?v=q6sXGdQ_knE).
-- [StrataLabs](https://www.stratalabs.io/) is the first commercial Interledger connector company, enabling micropayment services like Coil.
+- [StrataLabs](https://web.archive.org/web/20201113153526/https://www.stratalabs.io/) is the first commercial Interledger connector company, enabling micropayment services like Coil.
 - [Kava](https://kava.io/) runs an Interledger connector and is developing technology for the ILP ecosystem including new cross-currency integrations and a [Cosmos](https://cosmos.network/)\-based blockchain optimized for ILP.
 - [The Bill & Melinda Gates Foundation](https://www.gatesfoundation.org/What-We-Do/Global-Growth-and-Opportunity/Financial-Services-for-the-Poor) developed [Mojaloop](http://mojaloop.io/), an open source payment system for emerging markets, using Interledger to increase financial inclusion through interoperability.
 - Ilp.ix, an [mlab](https://mlab.company/) project, is an XRP peering exchange that helps connectors find and connect to one another.

--- a/src/layouts/BaseLayout.astro
+++ b/src/layouts/BaseLayout.astro
@@ -22,7 +22,7 @@ const { title, description } = Astro.props;
 		<meta name="generator" content={Astro.generator} />
 		<title>{title ? `${title} | Interledger Foundation` : 'Interledger Foundation'}</title>
 		<link rel="icon" type="image/svg+xml" href="/developers/favicon.svg" />
-		<script defer src="https://ilf-site-analytics.netlify.app/script.js" data-website-id="50d81dd1-bd02-4f82-8a55-34a09ccbbbd9"></script>
+		<script defer src="https://ilf-site-analytics.netlify.app/script.js" data-website-id="50d81dd1-bd02-4f82-8a55-34a09ccbbbd9" data-domains="interledger.org"></script>
 	</head>
 	
 	<body>

--- a/src/layouts/LanderLayout.astro
+++ b/src/layouts/LanderLayout.astro
@@ -22,7 +22,7 @@ const { title, description, gradient = "option1" } = Astro.props;
 		<meta name="generator" content={Astro.generator} />
 		<title>{title ? `${title} | Interledger Foundation` : 'Interledger Foundation'}</title>
 		<link rel="icon" type="image/svg+xml" href="/developers/favicon.svg" />
-		<script defer src="https://ilf-site-analytics.netlify.app/script.js" data-website-id="50d81dd1-bd02-4f82-8a55-34a09ccbbbd9"></script>
+		<script defer src="https://ilf-site-analytics.netlify.app/script.js" data-website-id="50d81dd1-bd02-4f82-8a55-34a09ccbbbd9" data-domains="interledger.org"></script>
 	</head>
 	
 	<body style=`--gradient:var(--${gradient})`>


### PR DESCRIPTION
This PR fixes a broken link on an old blog post and adds interledger.org as the domain for tracking to prevent muddying of statistics from local/staging environments.