### PR TITLE
feat: add LargeImg component

### DIFF
--- a/src/components/pages/LargeImg.astro
+++ b/src/components/pages/LargeImg.astro
@@ -1,0 +1,44 @@
+---
+const { src, alt, hasBorder = true } = Astro.props;
+---
+<div>
+  {hasBorder ? <img src={src} alt={alt} class="border" /> : <img src={src} alt={alt} />}
+  <a
+    href={src}
+    target='_blank'
+    rel='noopener noreferrer'
+  >
+    View full image
+  </a>
+</div>
+
+<style>
+div {
+  text-align: right;
+}
+
+img[src$='.svg' i] {
+  background-color: white;
+}
+
+.border {
+  border-radius: var(--border-radius);
+  box-shadow: var(--box-shadow);
+  border: 2px solid var(--color-accent-transparent);
+}
+
+a {
+  white-space: nowrap;
+  display: inline-flex;
+  gap: var(--space-3xs);
+  margin-block-start: var(--space-3xs);
+  margin-block-end: var(--space-s);
+  font-size: var(--step--1);
+}
+
+a::after {
+  content: url('data:image/svg+xml,<svg xmlns="http://www.w3.org/2000/svg" fill="none" viewBox="0 0 18 18"><path stroke="hsl(221,8%,56%)" stroke-linecap="round" stroke-linejoin="round" stroke-width="2" d="M7 3H3a2 2 0 0 0-2 2v10a2 2 0 0 0 2 2h10a2 2 0 0 0 2-2v-4M11 1h6m0 0v6m0-6L7 11"/></svg>');
+  height: 0.75em;
+  width: 0.75em;
+}
+</style>


### PR DESCRIPTION
This PR adds a LargeImg component to our engineering blog. This will cater to blog posts that come with larger/more detailed diagrams where users can choose to see the full image in another tab.

Usage is as follows:
- Make sure the blog post is in `.mdx` format
- Import the component at the top of the file just after the frontmatter
    ```mdx
    ---
    layout: ../../layouts/BlogLayout.astro
    title: "A Simple Guide to the Open Payments Standard"
    # more frontmatter stuff
    ---
    import LargeImg from '/src/components/pages/LargeImg.astro'

    ## The Current Digital Payments Landscape
    ```
- The component behaves similarly to a typical `img` tag, it takes in `src`, `alt` and a boolean `hasBorder` attribute, which determines if the image should have a light border around it or not. The `hasBorder` attribute is set to `true` by default.
    ```mdx
    <LargeImg src="/developers/img/blog/2024-06-20/credit-cards.png" alt="Most applications' payment implementation today" hasBorder={false} />
    ```