### PR TITLE
fix: increase site header z-index

### DIFF
--- a/src/components/pages/FoundationHeader.astro
+++ b/src/components/pages/FoundationHeader.astro
@@ -116,7 +116,7 @@ import FoundationLogo from "../logos/FoundationLogo.astro";
   padding: 0 var(--space-m);
   position: sticky;
   top: 0;
-  z-index: 1;
+  z-index: 2;
   border-block-start: 2px solid var(--color-header-accent);
   box-shadow: var(--box-shadow);
 }


### PR DESCRIPTION
Increases `site-header` `z-index` property. 
The copy button from the code block is displayed on top of the header:


<img width="990" alt="image" src="https://github.com/user-attachments/assets/3461410e-6a82-432e-953b-048e3de15a5c">
