### PR TITLE
chore: updated the link for the Hacktoberfest CTA

### DIFF
--- a/src/pages/index.astro
+++ b/src/pages/index.astro
@@ -51,7 +51,7 @@ import RafikiIcon from '../components/logos/RafikiIcon.astro';
         </div>
 
         <div class="card">
-          <h2 class="heading--6"><a href="https://github.com/interledger/hacktoberfest" data-umami-event="Devs page link - Hacktoberfest" target="_blank" rel="noopener noreferrer"><InterledgerIcon /> Hacktoberfest</a></h2>
+          <h2 class="heading--6"><a href="https://github.com/search?q=topic%3Ahacktoberfest+org%3Ainterledger+fork%3Atrue+repo%3Awicg%2Fwebmonetization&type=repositories" data-umami-event="Devs page link - Hacktoberfest" target="_blank" rel="noopener noreferrer"><InterledgerIcon /> Hacktoberfest</a></h2>
           <p>Join us this October to collaborate on our open source projects.</p>
         </div>
 


### PR DESCRIPTION
We need to update the Hacktoberfest CTA link on our [developer's portal](https://interledger.org/developers/).