### PR TITLE
chore: removed STREAM page's overview section

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -39,6 +39,7 @@ export default defineConfig({
       ],
       components: {
         Header: "./src/components/Header.astro",
+        PageSidebar: './src/components/PageSidebar.astro'
       },
       social: {
         github: "https://github.com/interledger",

--- a/src/components/PageSidebar.astro
+++ b/src/components/PageSidebar.astro
@@ -1,0 +1,17 @@
+---
+import type { Props } from '@astrojs/starlight/props';
+import Default from '@astrojs/starlight/components/PageSidebar.astro';
+
+const removeOverview = [
+ 'rfcs/stream-protocol',
+]
+const noOverview = removeOverview.includes(Astro.props.slug);
+const toc = noOverview && Astro.props.toc !== undefined
+	? {
+			...Astro.props.toc,
+			items: Astro.props.toc?.items.slice(1),
+	  } 
+	: Astro.props.toc;
+---
+
+<Default {...Astro.props} {toc}><slot /></Default>


### PR DESCRIPTION
Removing the sidebar Overview item on the ILP docs STREAM page.