### PR TITLE
feat: added basic site tracking to the ILP spec using Umami

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -36,6 +36,15 @@ export default defineConfig({
             defer: true,
           },
         },
+        {
+          tag: 'script',
+          attrs: {
+            defer: true,
+            'data-website-id': '50d81dd1-bd02-4f82-8a55-34a09ccbbbd9',
+            src: 'https://ilf-site-analytics.netlify.app/script.js',
+            'data-domains': 'interledger.org'
+          }
+        }
       ],
       components: {
         Header: "./src/components/Header.astro",


### PR DESCRIPTION
<!--
If updating the specs in /openapi, you can test the changes by opening a PR and checking the Netlify deploy preview
-->

## Changes proposed in this pull request

<!--
Provide a succinct description of what this pull request entails.
-->

Added an Umami site tracking script so that we can record page visits for the ILP spec.

## Context

<!--
What were you trying to do?
Link issues here -  using `fixes #number`
-->

This gets the basic infrastructure in place and allows us to track page views. There will be more work needed to add granular event tracking based on clicking links.  
