### PR TITLE
chore: style tweak to center blog images

### DIFF
--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -127,7 +127,8 @@ article :global(figure) {
   margin-block-end: var(--space-s);
 }
 
-article :global(h3) {
+article :global(h3),
+article :global(h4) {
   margin-block-end: var(--space-xs);
 }
 
@@ -212,5 +213,10 @@ article :global(code) {
 
 article :global(ul li) {
 	margin-block-end: var(--space-2xs);
+}
+
+article :global(img) {
+  display: block;
+  margin-inline: auto;
 }
 </style>


### PR DESCRIPTION
- Centralises blog images
- Adds a little padding below h4 headings on blogs