### PR TITLE
fix: pagination component url errors

### DIFF
--- a/src/components/blog/Pagination.astro
+++ b/src/components/blog/Pagination.astro
@@ -5,13 +5,13 @@ const paginationList = Array.from({length}, (_, i) => i + 1);
 ---
 <nav aria-label="Blog pages" class="pagination">
   {firstUrl ? (
-    <a href={`/developers${firstUrl}`} class="pagination__link">&#171;</a>
+    <a href={`${firstUrl}`} class="pagination__link">&#171;</a>
   ) : (
   <span class="pagination__link disabled">&#171;</span>
   )}
 
   {prevUrl ? (
-    <a href={`/developers${prevUrl}`} class="pagination__link">&#8249;</a>
+    <a href={`${prevUrl}`} class="pagination__link">&#8249;</a>
   ) : (
     <span class="pagination__link disabled">&#8249;</span>
   )}
@@ -28,11 +28,11 @@ const paginationList = Array.from({length}, (_, i) => i + 1);
   {!nextUrl ? (
     <span class="pagination__link disabled">&#8250;</span>
   ) : (
-    <a href={`/developers${nextUrl}`} class="pagination__link">&#8250;</a>
+    <a href={`${nextUrl}`} class="pagination__link">&#8250;</a>
   )}
 
   {lastUrl ? (
-    <a href={`/developers${lastUrl}`} class="pagination__link">&#187;</a>
+    <a href={`${lastUrl}`} class="pagination__link">&#187;</a>
   ) : (
     <span class="pagination__link disabled">&#187;</span>
   )}

--- a/src/pages/blog/[...id].astro
+++ b/src/pages/blog/[...id].astro
@@ -4,18 +4,17 @@ import BlogLayout from '../../layouts/BlogLayout.astro';
 import CommunityLinks from "../../components/blog/CommunityLinks.astro";
 
 export async function getStaticPaths() {
-  const posts = await getCollection('blog');
-  return posts.map(post => ({
-    params: { id: post.id },
-    props: { post },
+  const blogEntries = await getCollection('blog');
+  return blogEntries.map(entry => ({
+    params: { id: entry.id },
+    props: { entry },
   }));
 }
 
-const { post } = Astro.props;
-const { Content } = await render(post);
+const { entry } = Astro.props;
+const { Content } = await render(entry);
 ---
-<BlogLayout frontmatter={post.data}>
+<BlogLayout frontmatter={entry.data}>
   <Content />
   <CommunityLinks />
 </BlogLayout>
-


### PR DESCRIPTION
This PR updates the pagination component to take into account the patch fix in https://github.com/withastro/astro/releases/tag/astro%405.3.1, which now correctly appends the configured base path to `Astro.url` thus removing the need for the extra `/developers`.
