### PR TITLE
chore: updated main site navigation menu

### DIFF
--- a/src/components/pages/FoundationHeader.astro
+++ b/src/components/pages/FoundationHeader.astro
@@ -22,10 +22,10 @@ import FoundationLogo from "../logos/FoundationLogo.astro";
               <a href="/values" data-umami-event="Site Nav - Values">Values</a>
             </li>
             <li class="menu-item menu-item--level-2">
-              <a href="/team" data-umami-event="Site Nav - Team">Team</a>
+              <a href="/policy-and-advocacy" data-umami-event="Site Nav - Policy & Advocacy">Policy & Advocacy</a>
             </li>
             <li class="menu-item menu-item--level-2">
-              <a href="https://interledger-foundation.breezy.hr/" data-umami-event="Site Nav - Careers">Careers</a>
+              <a href="/team" data-umami-event="Site Nav - Team">Team</a>
             </li>
           </ul>
         </li>


### PR DESCRIPTION
Changes were made to the Drupal site navigation and need to be reflected here. The careers link is down for now and the Policy and Advocacy page needs to be included.