### PR TITLE
chore: bump dependencies to latest versions

### DIFF
--- a/astro.config.mjs
+++ b/astro.config.mjs
@@ -52,9 +52,7 @@ export default defineConfig({
         Header: "./src/components/Header.astro",
         PageSidebar: "./src/components/PageSidebar.astro",
       },
-      social: {
-        github: "https://github.com/interledger",
-      },
+      social: [{ icon: "github", label: "GitHub", href: "https://github.com/interledger" }],
       sidebar: [
         {
           label: "Overview",

--- a/package.json
+++ b/package.json
@@ -9,17 +9,17 @@
     "astro": "astro"
   },
   "dependencies": {
-    "@astrojs/mdx": "^4.0.8",
-    "@astrojs/node": "^9.1.0",
-    "@astrojs/starlight": "^0.31.1",
-    "@interledger/docs-design-system": "^0.6.1",
+    "@astrojs/mdx": "^4.2.3",
+    "@astrojs/node": "^9.1.3",
+    "@astrojs/starlight": "^0.33.0",
+    "@interledger/docs-design-system": "^0.6.2",
     "@types/showdown": "^2.0.6",
-    "astro": "^5.3.0",
+    "astro": "^5.6.1",
     "html-to-text": "^9.0.5",
     "markdown-it": "^14.1.0",
     "node-html-parser": "^7.0.1",
-    "sharp": "^0.33.5",
+    "sharp": "^0.34.1",
     "showdown": "^2.1.0",
-    "starlight-links-validator": "^0.14.2"
+    "starlight-links-validator": "^0.15.0"
   }
 }

--- a/src/components/Header.astro
+++ b/src/components/Header.astro
@@ -1,5 +1,4 @@
 ---
-import type { Props } from '@astrojs/starlight/props';
 import Search from "@astrojs/starlight/components/Search.astro";
 import SocialIcons from "@astrojs/starlight/components/SocialIcons.astro";
 import ThemeSelect from "@astrojs/starlight/components/ThemeSelect.astro";
@@ -22,11 +21,11 @@ import DevelopersLogo from "./logos/DevelopersLogo.astro";
         Interledger Foundation
       </span>
   </a>
-  <Search {...Astro.props} />
+  <Search />
   <div class="sl-hidden md:sl-flex secondary-wrap">
     
-    <SocialIcons {...Astro.props} />
-    <ThemeSelect {...Astro.props} />
+    <SocialIcons />
+    <ThemeSelect />
   </div>
 </div>
 

--- a/src/components/PageSidebar.astro
+++ b/src/components/PageSidebar.astro
@@ -1,17 +1,17 @@
 ---
-import type { Props } from '@astrojs/starlight/props';
 import Default from '@astrojs/starlight/components/PageSidebar.astro';
 
 const removeOverview = [
  'rfcs/stream-protocol',
 ]
-const noOverview = removeOverview.includes(Astro.props.slug);
-const toc = noOverview && Astro.props.toc !== undefined
-	? {
-			...Astro.props.toc,
-			items: Astro.props.toc?.items.slice(1),
-	  } 
-	: Astro.props.toc;
+const { id, toc } = Astro.locals.starlightRoute;
+const noOverview = removeOverview.includes(id);
+if (noOverview && toc) {
+	Astro.locals.starlightRoute.toc = {
+		...toc,
+		items: toc.items.slice(1),
+	};
+}
 ---
 
-<Default {...Astro.props} {toc}><slot /></Default>
+<Default />


### PR DESCRIPTION
This PR bumps dependencies to their latest versions. Updates the astro.config.mjs to address the breaking change from https://github.com/withastro/starlight/blob/main/packages/starlight/CHANGELOG.md#0330