### PR TITLE
chore: moved Technology tab, renamed Technology standards

### DIFF
--- a/src/components/pages/FoundationHeader.astro
+++ b/src/components/pages/FoundationHeader.astro
@@ -27,25 +27,10 @@ import FoundationLogo from "../logos/FoundationLogo.astro";
           </ul>
         </li>
         <li class="menu-item has-submenu menu-item--level-1">
-          <a href="/financial-services" aria-expanded="false" data-umami-event="Site Nav - Grants">Grants</a>
-          <ul class="menu--level-2">
-            <li class="menu-item menu-item--level-2">
-              <a href="/financial-services" data-umami-event="Site Nav - Financial Services">Financial Services</a>
-            </li>
-            <li class="menu-item menu-item--level-2">
-              <a href="/education" data-umami-event="Site Nav - Education">Education</a>
-            </li>
-            <li class="menu-item menu-item--level-2">
-              <a href="/ambassadors" data-umami-event="Site Nav - Ambassadors">Ambassadors</a>
-            </li>
-          </ul>
-        </li>
-        <li class="menu-item has-submenu menu-item--level-1">
           <a href="/developers" aria-expanded="false" data-umami-event="Site Nav - Technology">Technology</a>
           <ul class="menu--level-2">
-            </li>
             <li class="menu-item menu-item--level-2">
-              <a href="/open-standards" data-umami-event="Site Nav - Open Standards">Technology stack</a>
+              <a href="/open-standards" data-umami-event="Site Nav - Open Standards">Overview</a>
             </li>
             <li class="menu-item menu-item--level-2">
               <a href="/interledger" data-umami-event="Site Nav - Interledger">Interledger</a>
@@ -60,6 +45,20 @@ import FoundationLogo from "../logos/FoundationLogo.astro";
             </li>
             <li class="menu-item menu-item--level-2">
               <a href="/developers" data-umami-event="Site Nav - Developers Portal">Developers Portal</a>
+            </li>
+          </ul>
+        </li>
+        <li class="menu-item has-submenu menu-item--level-1">
+          <a href="/financial-services" aria-expanded="false" data-umami-event="Site Nav - Grants">Grants</a>
+          <ul class="menu--level-2">
+            <li class="menu-item menu-item--level-2">
+              <a href="/financial-services" data-umami-event="Site Nav - Financial Services">Financial Services</a>
+            </li>
+            <li class="menu-item menu-item--level-2">
+              <a href="/education" data-umami-event="Site Nav - Education">Education</a>
+            </li>
+            <li class="menu-item menu-item--level-2">
+              <a href="/ambassadors" data-umami-event="Site Nav - Ambassadors">Ambassadors</a>
             </li>
           </ul>
         </li>


### PR DESCRIPTION
Moved the Technology menu over to be next to the Foundation menu and changed "Technology Stack" to "Overview". Needs to match what's changed on Drupal.

You can test by spinning up Developers locally with `bun run start` 

![image](https://github.com/user-attachments/assets/e322d615-8135-45e0-ad50-c3a0b0334e94)