### PR TITLE
feat: add filter for Spanish blog posts and style tweaks

### DIFF
--- a/src/content.config.ts
+++ b/src/content.config.ts
@@ -10,6 +10,7 @@ const blogCollection = defineCollection({
     description: z.string(),
     slug: z.string(),
     date: z.date(),
+    lang: z.string().optional(),
     image: z.string().optional(),
     tags: z.array(z.string()),
     authors: z.array(z.string()),

--- a/src/content/blog/2025-06-04-ES-El-Universo-Interledger.mdx
+++ b/src/content/blog/2025-06-04-ES-El-Universo-Interledger.mdx
@@ -2,6 +2,7 @@
 title: "El Universo Interledger"
 description: "Explora el sistema abierto que conecta pagos globales con Interledger."
 date: 2025-07-02
+lang: es
 slug: el-universo-interledger
 authors:
   - Marian Villa
@@ -132,7 +133,7 @@ Un ejemplo de una dirección ILP luce así:
 
 Los [Apuntadores de pagos](https://paymentpointers.org/) son una forma amigable de representar las **direcciones ILP**, similar a cómo las URLs presentan las direcciones IP. Esto hace que sea más fácil para el usuario manejar y compartir sus direcciones de pago.
 
-Un apuntador de pago siempre tiene un prefijo de señal de dólar ($) seguido de una estructura similar a la de una URL. Por ejemplo: `$wallet.com/alice`este apuntador de pago resuelve en una url`https://wallet.com/alice` que apunta a una dirección ILP.
+Un apuntador de pago siempre tiene un prefijo de señal de dólar ($) seguido de una estructura similar a la de una URL. Por ejemplo: `$wallet.com/alice` este apuntador de pago resuelve en una url`https://wallet.com/alice` que apunta a una dirección ILP.
 
 Un ejemplo: `test.wallet.alice` (Que no contiene la parte de interacción).
 

--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -205,10 +205,10 @@ article :global(.expressive-code) {
 	margin-block-end: var(--space-s);
 }
 
-article :global(code) {
+article :global(:not(pre) > code) {
 	background-color: var(--color-bg-inline-code);
 	border-radius: var(--border-radius);
-	font-size: var(--step--2);
+	font-size: var(--step--1);
 	padding: 0.125rem 0.375rem;
 	overflow-wrap: anywhere;
 }

--- a/src/pages/blog/es.astro
+++ b/src/pages/blog/es.astro
@@ -1,22 +1,16 @@
 ---
-import type { Page } from "astro";
+import { getCollection } from 'astro:content';
 import { createExcerpt } from '../../utils/create-excerpt';
 import BaseLayout from '../../layouts/BaseLayout.astro';
-import Pagination from '../../components/blog/Pagination.astro';
-import { getCollection } from 'astro:content';
 
-type Props = {
-  page: Page<any>;
-};
 
-export async function getStaticPaths({ paginate }: any) {
-  const blogEntries = (await getCollection("blog")).sort((a:any, b:any) => b.data.date.getTime() - a.data.date.getTime());
-  return paginate(blogEntries, { pageSize: 10 });
-}
-
-const { page } = Astro.props;
+// Only return posts with `draft: true` in the frontmatter
+const esEntries = await getCollection('blog', ({ data }) => {
+  return data.lang === 'es';
+});
+console.log(typeof esEntries, esEntries.length, esEntries[0]?.data?.title);
 ---
-<BaseLayout title="Engineering Blog" description="Hear stories and experiences from the team who is working on making Interledger, the interoperable global payments network, a reality." ogImageUrl={new URL('/developers/img/blog/og-image.png', Astro.site).href}>
+<BaseLayout title="Blog de Ingeniería" description="Hear stories and experiences from the team who is working on making Interledger, the interoperable global payments network, a reality." ogImageUrl={new URL('/developers/img/blog/og-image.png', Astro.site).href}>
 	<main>
 		<div class="content-wrapper">
 			<ol class="breadcrumbs" itemscope itemtype="https://schema.org/BreadcrumbList">
@@ -28,39 +22,26 @@ const { page } = Astro.props;
 				</li>
 			</ol>
 			<header>
-				<h1>Engineering Blog</h1>
+				<h1>Blog de Ingeniería</h1>
 				<a class="cta__blog" href="/blog">
 					<p>Check out Foundation updates</p>
 					<img src="/developers/img/ernie-purple.svg" alt="Ernie holding an envelope" aria-hidden="true">
 				</a>
 			</header>
 			<ol class="postlist">
-				{((page as any).data || []).map((blogPostEntry: any) => {
+				{(esEntries as any).map((blogPostEntry: any) => {
 					const excerpt = `${createExcerpt(blogPostEntry.body).substring(0, 300)}...`;
 					return (
 						<li class="postlist-item">
 							<time class="postlist-date" datetime={blogPostEntry.data.date.toISOString()}>
 								{blogPostEntry.data.date.toDateString()}
 							</time>
-							{blogPostEntry.data.lang ? 
-								<div class="postlist-es">
-									<a href={`/developers/blog/${blogPostEntry.id}`} class="postlist-link heading--6">{blogPostEntry.data.title}</a>
-									<a class="postlist-lang" href="/developers/blog/es">ES</a>
-								</div> :
-								<a href={`/developers/blog/${blogPostEntry.id}`} class="postlist-link heading--6">{blogPostEntry.data.title}</a>
-							}
+							<a href={`/developers/blog/${blogPostEntry.id}`} class="postlist-link heading--6">{blogPostEntry.data.title}</a>
 							<p>{blogPostEntry.data.description ? blogPostEntry.data.description : excerpt}</p>
 						</li>
 					)}
 				)}
 			</ol>
-			<Pagination length={page.lastPage}
-				currentPage={page.currentPage} 
-				firstUrl={page.url.first} 
-				prevUrl={page.url.prev}
-				nextUrl={page.url.next}
-				lastUrl={page.url.last}
-			/>
 		</div>
 	</main>
 </PageLayout>
@@ -159,22 +140,6 @@ header {
 
 .postlist-link:hover {
   text-decoration-color: currentColor;
-}
-
-.postlist-es {
-	display: flex;
-	align-items: start;
-	gap: var(--space-2xs);
-}
-
-.postlist-lang {
-	border: 1.5px solid;
-	padding-inline: 4px;
-	border-radius: var(--border-radius);
-	font-size: var(--step--1);
-	background-color: white;
-	margin-block-start: var(--space-3xs);
-	text-decoration: none;
 }
 </style>
 


### PR DESCRIPTION
This PR:
- adds a landing page that lists all Spanish language blog posts at /developers/blog/es, which are identified by the front matter field "lang"
    - Only blog posts containing the property `lang: es` will show up on that page
- adjusts some styling for individual blog posts

This decision to not do a full-fledged i18n of the blog is because we will not be translating most of the blog posts, only a select few in preparation for the Summit and Hackathon, therefore the effort to properly i18n-ise the blog was not considered commensurate to the end result.

In future, if we want to fully invest in multilingual content, then we can consider implementing a complete i18n solution.