### PR TITLE
fix: add ES blog navigation options

### DIFF
--- a/src/layouts/BlogLayout.astro
+++ b/src/layouts/BlogLayout.astro
@@ -25,6 +25,11 @@ const rawHTMLString = `This article was originally published at <a href=${frontm
 					<a itemprop="item" href="/developers/blog" data-umami-event="Devs breadcrumb - Blog">
 					<span itemprop="name">Engineering Blog</span></a>
 					<meta itemprop="position" content="2" />
+					{frontmatter.lang &&
+						<span>|</span>
+						<a itemprop="item" href="/developers/blog/es" data-umami-event="Devs breadcrumb - ES blogs">
+						<span itemprop="name">Blog de Ingeniería</span></a>
+					}
 				</li>
 			</ol>
 			<h1>{frontmatter.title}</h1>
@@ -70,7 +75,6 @@ main {
   display: inline-flex;
   margin-inline-start: var(--space-3xs);
 }
-
 
 article {
 	--max-content-width: 960px;

--- a/src/pages/blog/es.astro
+++ b/src/pages/blog/es.astro
@@ -20,6 +20,12 @@ console.log(typeof esEntries, esEntries.length, esEntries[0]?.data?.title);
 					<span itemprop="name">Developers Portal</span></a>
 					<meta itemprop="position" content="1" />
 				</li>
+				<li itemprop="itemListElement" itemscope
+						itemtype="https://schema.org/ListItem">
+					<a itemprop="item" href="/developers/blog" data-umami-event="Devs breadcrumb - Blog">
+					<span itemprop="name">Engineering Blog</span></a>
+					<meta itemprop="position" content="2" />
+				</li>
 			</ol>
 			<header>
 				<h1>Blog de Ingeniería</h1>
@@ -64,6 +70,12 @@ main {
 .breadcrumbs a {
 	color: var(--color-primary);
 	text-decoration: none;
+}
+
+.breadcrumbs li:not(:first-child)::before {
+  content: '>';
+  display: inline-flex;
+  margin-inline-start: var(--space-3xs);
 }
 
 ol {


### PR DESCRIPTION
This PR adds a more convenient way to access the full blog list from the Spanish article and landing page 