### PR TITLE
chore: added a PR template to GitHub with checklist reminders

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,0 +1,8 @@
+## PR Checklist
+- [ ] Linked issue added (e.g., `Fixes #123`)
+- [ ] If blog post was added:
+  - [ ] Ensure images have been optimised
+  - [ ] Update dates to reflect the actual publishing date when merged (file names, folder names, and frontmatter)
+
+## Summary
+<!-- What has been updated and why -->


### PR DESCRIPTION
When someone creates a PR with a new blog entry they need to know to update the dates to the merge date, so I've created a PR template with a checklist to remind them. 