### PR TITLE
chore: removed duplicated Integrations blog tag

### DIFF
--- a/src/content/blog/2026-04-03-integrations-work-week.md
+++ b/src/content/blog/2026-04-03-integrations-work-week.md
@@ -9,7 +9,7 @@ author_urls:
   - https://github.com/tymmmy
 tags:
   - WorkWeek
-  - Integrations
+  - Integration
 ---
 
 Every so often, we take a step back from the day-to-day development and dedicate focused time to push forward some ideas that are always put on the sidelines. This time around, we ran a three-day work week in Cluj-Napoca, labeled as Integrations Work Week, but we made space for the Interledger Wallet team as well, so we decided to structure and accommodate five tracks: **POS App for Android**, **Integrations Initial Guidebook**, **Integrating Rafiki into the New Architecture**, **POC for Peering with the Test Wallet**, and **Log and Error Hunt**. It was three days packed with deep dives, live demos, lively debates, and, as always, good conversations, good food, even better coffee and desserts and a wonderful team dinner. Here's how it all went down.


### PR DESCRIPTION
## PR Checklist
- [ ] Linked issue added (e.g., `Fixes #123`)
- [ ] I have run `bun run format` to ensure code is properly formatted
- [ ] I have verified that `bun run lint` passes without errors
- [ ] If blog post was added:
  - [ ] Ensure images have been optimised
  - [ ] Update dates to reflect the actual publishing date when merged (file names, folder names, and frontmatter)

## Summary
<!-- What has been updated and why -->
Integration and Integrations tags are both listed

<img width="1319" height="325" alt="image" src="https://github.com/user-attachments/assets/d20b3f6e-d767-4b43-a20f-bab065ae17e9" />

See https://deploy-preview-214--developers-preview.netlify.app/developers/blog/

