### PR TITLE
fix: Blog tags should have spaces

### DIFF
--- a/src/content/blog/2026-04-03-integrations-work-week.md
+++ b/src/content/blog/2026-04-03-integrations-work-week.md
@@ -8,7 +8,7 @@ authors:
 author_urls:
   - https://github.com/tymmmy
 tags:
-  - WorkWeek
+  - Work Week
   - Integration
 ---
 


### PR DESCRIPTION
## PR Checklist
- [ ] Linked issue added (e.g., `Fixes #123`)
- [ ] I have run `bun run format` to ensure code is properly formatted
- [ ] I have verified that `bun run lint` passes without errors
- [ ] If blog post was added:
  - [ ] Ensure images have been optimised
  - [ ] Update dates to reflect the actual publishing date when merged (file names, folder names, and frontmatter)

## Summary
<!-- What has been updated and why -->
Blog tags should have spaces
