### PR TITLE
chore: proxy content from the netlify service

### DIFF
--- a/.github/workflows/deploy_gcs.yml
+++ b/.github/workflows/deploy_gcs.yml
@@ -1,18 +1,14 @@
-name: Deploy to GCS
+name: Deploy nginx proxy to Cloud Run
 
 on:
-  # Trigger the workflow every time you push to the `main` branch
-  # Using a different branch name? Replace `main` with your branch's name
   push:
     branches: [main]
-  # Allows you to run this workflow manually from the Actions tab on GitHub.
+    paths:
+      - 'ci/nginx-rewrite/**'
   workflow_dispatch:
 
-# Allow this job to clone the repo and create a page deployment
 permissions:
   contents: read
-  pages: write
-  id-token: write
 
 jobs:
   deploy:
@@ -20,9 +16,6 @@ jobs:
     steps:
       - name: Checkout your repository using git
         uses: actions/checkout@v4
-      - uses: actions/setup-node@v4
-        with:
-          node-version: 22
 
       - name: Authenticate to Google Cloud
         uses: google-github-actions/auth@v2
@@ -31,15 +24,6 @@ jobs:
 
       - name: Set up Cloud SDK
         uses: google-github-actions/setup-gcloud@v2
-
-      - uses: oven-sh/setup-bun@v1
-      - name: Install dependencies
-        run: bun install
-      - name: Test build website
-        run: bun run build
-
-      - name: Deploy to GCS
-        run: gsutil -m rsync -r -d ./dist/ gs://${{ secrets.GCS_BUCKET }}/developers
 
       - name: Build nginx container
         run: |
@@ -59,9 +43,3 @@ jobs:
             --min-instances 0 \
             --max-instances 10 \
             --quiet
-
-      - name: Invalidate CDN cache
-        run: |
-          gcloud compute url-maps invalidate-cdn-cache interledger-org \
-            --path "/developers/*" \
-            --async

--- a/.github/workflows/invalidate-cdn.yml
+++ b/.github/workflows/invalidate-cdn.yml
@@ -1,0 +1,25 @@
+name: Invalidate CDN
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: read
+
+jobs:
+  invalidate:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Authenticate to Google Cloud
+        uses: google-github-actions/auth@v2
+        with:
+          credentials_json: ${{ secrets.GSA_JSON }}
+
+      - name: Set up Cloud SDK
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Invalidate CDN cache for /developers/*
+        run: |
+          gcloud compute url-maps invalidate-cdn-cache interledger-org \
+            --path "/developers/*" \
+            --async

--- a/README.md
+++ b/README.md
@@ -81,18 +81,21 @@ This project has two deployment mechanisms:
 
 Every pull request automatically generates a preview deployment on Netlify at `https://deploy-preview-{PR_NUMBER}--developers-preview.netlify.app/developers/`. This allows reviewers to see changes before they're merged. The Netlify configuration is defined in `netlify.toml`.
 
-### Production Deployments (Google Cloud Storage)
+### Production Deployments (Netlify + GCP proxy)
 
-The real production deployment is served through Google Cloud Storage (GCS) at `https://interledger.org/developers/` as part of the main Interledger website. This is a transparent proxy configuration - the developers portal is hosted separately but appears as part of the main domain.
+The production site is built and hosted on Netlify, but users access it at `https://interledger.org/developers/` via the main Interledger load balancer. A small nginx service on Cloud Run proxies `/developers/*` requests from the GCP load balancer to the Netlify-hosted site, so the browser URL stays on `interledger.org`.
 
-When a PR is merged to the `main` branch, the `.github/workflows/deploy_gcs.yml` GitHub Actions workflow automatically:
+When a PR is merged to `main`, Netlify builds and publishes the new site automatically. GCP's Cloud CDN sits in front of the nginx proxy and caches responses for up to 1 hour.
 
-1. Builds the site using Bun
-2. Deploys the built files to Google Cloud Storage (`gs://interledger-websites-public/developers`)
-3. Rebuilds and deploys the nginx-rewrite Cloud Run service (which handles the `/developers` proxy routing)
-4. Invalidates the CDN cache to ensure new content is served immediately
+#### Invalidating the CDN after a deploy
 
-**Note:** There is a legacy `deploy.yaml` workflow in `.github/workflows/` which is being deprecated. New deployments should use `deploy_gcs.yml`.
+Because GCP Cloud CDN caches `/developers/*`, newly deployed content may take up to an hour to appear on `interledger.org/developers/`. If you need changes to go live immediately, manually trigger the **Invalidate CDN** workflow:
+
+1. Go to the repo's **Actions** tab on GitHub.
+2. Select the **Invalidate CDN** workflow.
+3. Click **Run workflow** on the `main` branch.
+
+This runs `gcloud compute url-maps invalidate-cdn-cache` against `/developers/*` and typically propagates within a minute.
 
 For more information about the main Interledger.org infrastructure and deployment pipeline, see the [`interledger.org-v4`](https://github.com/interledger/interledger.org-v4) repository.
 

--- a/ci/nginx-rewrite/Dockerfile
+++ b/ci/nginx-rewrite/Dockerfile
@@ -1,13 +1,7 @@
-FROM google/cloud-sdk:alpine AS fetcher
-
-# Fetch the developers content from GCS
-RUN mkdir -p /content/developers && \
-    gsutil -m rsync -r gs://interledger-org-developers-portal/developers/ /content/developers/
-
 FROM nginx:alpine
 
-# Copy the fetched content
-COPY --from=fetcher /content /usr/share/nginx/html
+# Install ca-certificates for SSL verification when proxying to Netlify
+RUN apk add --no-cache ca-certificates
 
 # Copy custom nginx configuration
 COPY nginx.conf /etc/nginx/nginx.conf
@@ -16,8 +10,7 @@ COPY nginx.conf /etc/nginx/nginx.conf
 RUN touch /var/run/nginx.pid && \
     chown -R nginx:nginx /var/run/nginx.pid && \
     chown -R nginx:nginx /var/cache/nginx && \
-    chown -R nginx:nginx /var/log/nginx && \
-    chown -R nginx:nginx /usr/share/nginx/html
+    chown -R nginx:nginx /var/log/nginx
 
 USER nginx
 

--- a/ci/nginx-rewrite/nginx.conf
+++ b/ci/nginx-rewrite/nginx.conf
@@ -23,15 +23,9 @@ http {
     types_hash_max_size 2048;
     gzip on;
 
-    # Use relative redirects
-    absolute_redirect off;
-
     server {
         listen 8080;
         server_name _;
-
-        # Root directory containing the developers folder
-        root /usr/share/nginx/html;
 
         # Health check endpoint for Cloud Run
         location /health {
@@ -40,14 +34,17 @@ http {
             add_header Content-Type text/plain;
         }
 
-        # Serve files under /developers/
+        # Proxy /developers/ requests to Netlify
         location /developers/ {
-            # This will:
-            # /developers/                -> /developers/index.html
-            # /developers/foo             -> /developers/foo/index.html
-            # /developers/foo/            -> /developers/foo/index.html
-            # /developers/foo/bar/        -> /developers/foo/bar/index.html
-            try_files $uri $uri/ $uri/index.html =404;
+            proxy_pass https://interledger-org-developers.netlify.app;
+            proxy_set_header Host interledger-org-developers.netlify.app;
+            proxy_set_header X-Real-IP $remote_addr;
+            proxy_set_header X-Forwarded-For $proxy_add_x_forwarded_for;
+            proxy_set_header X-Forwarded-Proto $scheme;
+            proxy_ssl_server_name on;
+            proxy_ssl_verify on;
+            # Rewrite any absolute Location headers from Netlify back to relative paths
+            proxy_redirect https://interledger-org-developers.netlify.app /;
         }
 
         # If someone hits /developers (no slash), redirect to /developers/


### PR DESCRIPTION
## Summary
This PR reworks the containers and their configuration to ensure we proxy the service from content coming from Netlify instead of the GCS bucket.

- Adds a new workflow to allow users to manually invalidate the GCP CDN
- nginx configuration will now source content from Netlify
- nginx configuration will rewrite host and /developer path appropriately
- Cleans up some legacy functionality

---

This pull request refactors the deployment pipeline for the `/developers` site by switching from serving static files from GCS to proxying requests to the Netlify deployment via an NGINX container on Cloud Run. It also separates CDN cache invalidation into a dedicated workflow and simplifies the NGINX setup. The most important changes are:

**Deployment workflow changes:**
* [`.github/workflows/deploy_gcs.yml`](diffhunk://#diff-1b4b1ebc2bdf979ebb337fbe79c15e0a7032d263c9252e0c5c584b213052f21bL1-L25): The workflow is renamed to "Deploy nginx proxy to Cloud Run" and now only triggers when files in `ci/nginx-rewrite/**` are changed. The build and deploy steps for the static site to GCS are removed, as well as the CDN cache invalidation step. The workflow now builds and deploys only the NGINX container. [[1]](diffhunk://#diff-1b4b1ebc2bdf979ebb337fbe79c15e0a7032d263c9252e0c5c584b213052f21bL1-L25) [[2]](diffhunk://#diff-1b4b1ebc2bdf979ebb337fbe79c15e0a7032d263c9252e0c5c584b213052f21bL35-L43) [[3]](diffhunk://#diff-1b4b1ebc2bdf979ebb337fbe79c15e0a7032d263c9252e0c5c584b213052f21bL62-L67)

**CDN cache invalidation:**
* [`.github/workflows/invalidate-cdn.yml`](diffhunk://#diff-681d70fc4853c54f2e376212d8332d7fef902c66953f0c10caa1888da8bf2525R1-R25): A new workflow is added to handle CDN cache invalidation for `/developers/*` as a separate, manually-triggered job.

**NGINX container and proxy configuration:**
* [`ci/nginx-rewrite/Dockerfile`](diffhunk://#diff-0467814882cf41c18f620d6146df7793a7b00b70f7da33cbfbea3dded974b441L1-R4): The multi-stage build that fetched static content from GCS is removed. The container now installs `ca-certificates` for SSL proxying and no longer copies content to the image.
* [`ci/nginx-rewrite/nginx.conf`](diffhunk://#diff-e84347fcb0b04b6e8fc158235bf34afb0ed65d5cec7e22cce739716a347b347aL26-R47): The server no longer serves static files from the container. Instead, all `/developers/` requests are proxied to the Netlify deployment, with appropriate headers and SSL verification.
* [`ci/nginx-rewrite/Dockerfile`](diffhunk://#diff-0467814882cf41c18f620d6146df7793a7b00b70f7da33cbfbea3dded974b441L19-R13): File and directory permissions are updated to remove ownership changes for the now-unused static content directory.