### PR TITLE
chore: update menu to point to hackathons not summit

### DIFF
--- a/src/components/pages/FoundationHeader.astro
+++ b/src/components/pages/FoundationHeader.astro
@@ -213,8 +213,8 @@ import FoundationLogo from '../logos/FoundationLogo.astro'
       </ul>
       <a
         class="switch-link"
-        href="/summit"
-        data-umami-event="Site Nav - Summit Link">Interledger Summit</a
+        href="/summit/hackathon"
+        data-umami-event="Site Nav - Hackathon link">Interledger Hackathons</a
       >
     </div>
     <button


### PR DESCRIPTION
Fixes INTORG-867

Can someone please approve for me. We're updating the menu to point to the hackathons instead of the summit 

## PR Checklist
- [x] Linked issue added (e.g., `Fixes #123`)
- [x] I have run `bun run format` to ensure code is properly formatted
- [x] I have verified that `bun run lint` passes without errors
- [ ] If blog post was added:
  - [ ] Ensure images have been optimised
  - [ ] Update dates to reflect the actual publishing date when merged (file names, folder names, and frontmatter)

## Summary
<!-- What has been updated and why -->
