### PR TITLE
docs: change ase reference to fsp

### DIFF
--- a/src/content/docs/get-started.md
+++ b/src/content/docs/get-started.md
@@ -13,7 +13,7 @@ Interledger Protocol (ILP) is an open protocol suite for sending packets of valu
     <img src="/developers/img/routing.svg" alt="">
     <div>
       <p><strong>Multi-Hop Routing</strong></p>
-      <p>Send payments to other ASEs on the network, even if they are multiple hops away.</p>
+      <p>Send payments to other financial service providers on the network, even if they're multiple hops away.</p>
     </div>
   </div>
   <div class="overview-item">


### PR DESCRIPTION
Fixes DOC-92

Does **not** address blog posts.

## PR Checklist
- [X] Linked issue added (e.g., `Fixes #123`)
- [ ] ~~I have run `bun run format` to ensure code is properly formatted~~ /bin/bash: prettier: command not found
error: script "format" exited with code 127
- [ ] ~~I have verified that `bun run lint` passes without errors~~
- [NA] If blog post was added:
  - [ ] Ensure images have been optimised
  - [ ] Update dates to reflect the actual publishing date when merged (file names, folder names, and frontmatter)

## Summary
<!-- What has been updated and why -->
